### PR TITLE
Extract query pagination mechanism into a React hook

### DIFF
--- a/src/hooks/useParamsHistoryData.js
+++ b/src/hooks/useParamsHistoryData.js
@@ -2,11 +2,6 @@ import { useQuery } from '@apollo/client';
 import { useEffect, useMemo } from 'react';
 
 function useParamsHistoryData(query, symbol, timestampMax, timestampMin) {
-  const debugQueryName = useMemo(() => query.definitions[0]?.name?.value, [
-    query,
-  ]);
-
-  console.log(debugQueryName, 'BEGIN useParamsHistoryData');
   const queryResult = useQuery(query, {
     variables: {
       symbol,
@@ -16,8 +11,7 @@ function useParamsHistoryData(query, symbol, timestampMax, timestampMin) {
     },
   });
 
-  const { loading, data, fetchMore } = queryResult;
-
+  const { data, fetchMore } = queryResult;
   const paramsHistory = data?.reserves?.[0]?.paramsHistory;
 
   const maxLoadedTimestamp = useMemo(
@@ -28,28 +22,18 @@ function useParamsHistoryData(query, symbol, timestampMax, timestampMin) {
     [paramsHistory]
   );
 
-  console.log(debugQueryName, {
-    loading,
-    maxLoadedTimestamp,
-    data,
-    paramsHistory,
-  });
-
   useEffect(() => {
-    console.log(debugQueryName, 'run useEffect, ', { maxLoadedTimestamp });
     if (!maxLoadedTimestamp) return;
 
     (async function () {
-      console.log(debugQueryName, 'run fetchMore! w/', { maxLoadedTimestamp });
       fetchMore({
         variables: {
           timestamp_gt: maxLoadedTimestamp,
         },
       });
     })();
-  }, [maxLoadedTimestamp, fetchMore, debugQueryName]);
+  }, [maxLoadedTimestamp, fetchMore]);
 
-  console.log(debugQueryName, 'END useParamsHistoryData');
   return queryResult;
 }
 

--- a/src/hooks/useParamsHistoryData.js
+++ b/src/hooks/useParamsHistoryData.js
@@ -1,0 +1,56 @@
+import { useQuery } from '@apollo/client';
+import { useEffect, useMemo } from 'react';
+
+function useParamsHistoryData(query, symbol, timestampMax, timestampMin) {
+  const debugQueryName = useMemo(() => query.definitions[0]?.name?.value, [
+    query,
+  ]);
+
+  console.log(debugQueryName, 'BEGIN useParamsHistoryData');
+  const queryResult = useQuery(query, {
+    variables: {
+      symbol,
+      timestamp_gt: timestampMin,
+      timestamp_lte: timestampMax,
+      first: 1000,
+    },
+  });
+
+  const { loading, data, fetchMore } = queryResult;
+
+  const paramsHistory = data?.reserves?.[0]?.paramsHistory;
+
+  const maxLoadedTimestamp = useMemo(
+    () =>
+      paramsHistory
+        ?.map(({ timestamp }) => timestamp)
+        ?.reduce((prev, current) => Math.max(prev, current), 0),
+    [paramsHistory]
+  );
+
+  console.log(debugQueryName, {
+    loading,
+    maxLoadedTimestamp,
+    data,
+    paramsHistory,
+  });
+
+  useEffect(() => {
+    console.log(debugQueryName, 'run useEffect, ', { maxLoadedTimestamp });
+    if (!maxLoadedTimestamp) return;
+
+    (async function () {
+      console.log(debugQueryName, 'run fetchMore! w/', { maxLoadedTimestamp });
+      fetchMore({
+        variables: {
+          timestamp_gt: maxLoadedTimestamp,
+        },
+      });
+    })();
+  }, [maxLoadedTimestamp, fetchMore, debugQueryName]);
+
+  console.log(debugQueryName, 'END useParamsHistoryData');
+  return queryResult;
+}
+
+export { useParamsHistoryData };


### PR DESCRIPTION
This PR extracts paginated data loading into a hook. You can use it like so:

```javascript
import { useParamsHistoryData } from '../hooks/useParamsHistoryData';

// …
  const {
    data: dataAvg,
    loading: loadingAvg,
    error: errorAvg,
  } = useParamsHistoryData(
    GET_HISTORICAL_ASSET_DATA_FOR_AVG_APY,
    asset,
    now,
    daysAgo30
  );
```